### PR TITLE
Added unload texture function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,8 @@ int main()
         EndDrawing();
     }
 
-    CloseWindow();
+    UnloadTexture(texture);
 
+    CloseWindow();
     return 0;
 }


### PR DESCRIPTION
Raylib is written in C, so cleaning up resources (such as textures, images, or sounds) must be done manually